### PR TITLE
Fix divide and substract in ng calculator, app.components.ts

### DIFF
--- a/calculator/angular/calculator/src/app/app.component.ts
+++ b/calculator/angular/calculator/src/app/app.component.ts
@@ -52,7 +52,7 @@ export class AppComponent {
   }
 
   divide() {
-      this.operator = (a, b) => a / b;
+      this.operator = (a, b) => b / a;
       this.setPrevious();
   }
 
@@ -62,7 +62,7 @@ export class AppComponent {
   }
 
   subtract() {
-      this.operator = (a, b) => a - b;
+      this.operator = (a, b) => b - a;
       this.setPrevious();
   }
 


### PR DESCRIPTION
I fixed a small bug in the Angular calculator for the functions `divide()` and `subtract()`